### PR TITLE
feat : Add click event listeners to banner arrows

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -16,3 +16,13 @@ const slides = [
 		"tagLine":"Autocollants <span>avec découpe laser sur mesure</span>"
 	}
 ]
+
+let flecheGauche = document.querySelector("#banner .arrow_left")
+flecheGauche.addEventListener("click", ()=> {
+	console.log("Clic sur flèche de gauche")
+})
+
+let flecheDroite = document.querySelector("#banner .arrow_right")
+flecheDroite.addEventListener("click", ()=> {
+	console.log("Clic sur flèche de droite")
+})


### PR DESCRIPTION
Added event listeners for left and right arrow elements in the banner. Clicking these arrows now logs a message to the console, preparing for future navigation functionality.